### PR TITLE
Python 2 StringIO fix

### DIFF
--- a/cppimport/import_hook.py
+++ b/cppimport/import_hook.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import io
 import shutil
 import string
 import tempfile
@@ -13,6 +12,11 @@ import hashlib
 import setuptools
 import setuptools.command.build_ext
 import pybind11
+
+if sys.version_info[0] == 2:
+    import StringIO as io
+else:
+    import io
 
 @contextlib.contextmanager
 def stdchannel_redirected(stdchannel):


### PR DESCRIPTION
This PR fixes an error encountered when running `import mymodule` with `quiet=False` in Python 2.7(.6)

Here's the top and bottom of the traceback of the following code

```python
import cppimport
import mymodule
cppimport.set_quiet(False)
```

```python
  File "/usr/local/lib/python2.7/dist-packages/cppimport-0.0.10-py2.7.egg/cppimport/import_hook.py", line 178, in build_plugin
    setuptools.setup(**setuptools_args)
.
.
.
  File "/usr/lib/python2.7/distutils/log.py", line 30, in _log
    stream.write('%s\n' % msg)
TypeError: unicode argument expected, got 'str'
```

Fix tested `test.py` with Python 2.7.6 and Python 3.4.3