### PR TITLE
Please remove -Wall and -Werror

### DIFF
--- a/cppimport/import_hook.py
+++ b/cppimport/import_hook.py
@@ -154,7 +154,7 @@ def build_plugin(full_module_name, filepath):
             pybind11.get_include(True)
         ],
         extra_compile_args = [
-            '-std=c++11', '-Wall', '-Werror'
+            '-std=c++11'
         ]
     )
 


### PR DESCRIPTION
I cannot compile most of my stuff with those two flags.

At least an option to unset them would be very much appreciated :)

ie. this is what I get for a very fine CPP file on Fedora 23:

```
In file included from /usr/include/python2.7/pyconfig.h:6:0,
                 from /usr/include/python2.7/Python.h:8,
                 from /usr/include/python2.7/pybind11/common.h:47,
                 from /usr/include/python2.7/pybind11/pytypes.h:12,
                 from /usr/include/python2.7/pybind11/cast.h:13,
                 from /usr/include/python2.7/pybind11/attr.h:13,
                 from /usr/include/python2.7/pybind11/pybind11.h:30,
                 from /tmp/tmpFYaNdg/crazy_stuff.cpp:5:
/usr/include/python2.7/pyconfig-64.h:1203:0: warning: "_POSIX_C_SOURCE" redefined
 #define _POSIX_C_SOURCE 200112L
 ^
In file included from /usr/include/c++/5.3.1/x86_64-redhat-linux/bits/os_defines.h:39:0,
                 from /usr/include/c++/5.3.1/x86_64-redhat-linux/bits/c++config.h:2255,
                 from /usr/include/c++/5.3.1/cmath:41,
                 from /tmp/tmpFYaNdg/crazy_stuff.cpp:3:
/usr/include/features.h:225:0: note: this is the location of the previous definition
 # define _POSIX_C_SOURCE 200809L
 ^
In file included from /usr/include/python2.7/pyconfig.h:6:0,
                 from /usr/include/python2.7/Python.h:8,
                 from /usr/include/python2.7/pybind11/common.h:47,
                 from /usr/include/python2.7/pybind11/pytypes.h:12,
                 from /usr/include/python2.7/pybind11/cast.h:13,
                 from /usr/include/python2.7/pybind11/attr.h:13,
                 from /usr/include/python2.7/pybind11/pybind11.h:30,
                 from /tmp/tmpFYaNdg/crazy_stuff.cpp:5:
/usr/include/python2.7/pyconfig-64.h:1225:0: warning: "_XOPEN_SOURCE" redefined
 #define _XOPEN_SOURCE 600
 ^
In file included from /usr/include/c++/5.3.1/x86_64-redhat-linux/bits/os_defines.h:39:0,
                 from /usr/include/c++/5.3.1/x86_64-redhat-linux/bits/c++config.h:2255,
                 from /usr/include/c++/5.3.1/cmath:41,
                 from /tmp/tmpFYaNdg/crazy_stuff.cpp:3:
/usr/include/features.h:166:0: note: this is the location of the previous definition
 # define _XOPEN_SOURCE 700
```