### PR TITLE
Adds support for setting libraries and external sources

### DIFF
--- a/cppimport/build_module.py
+++ b/cppimport/build_module.py
@@ -62,10 +62,11 @@ def build_module(module_data):
         os.path.dirname(filepath),
         full_module_name,
         language = 'c++',
-        sources = [module_data['rendered_src_filepath']],
+        sources = [module_data['rendered_src_filepath']] + cfg.get('sources', []),
         include_dirs = cfg.get('include_dirs', []) + [os.path.dirname(filepath)],
         extra_compile_args = cfg.get('compiler_args', []),
-        extra_link_args = cfg.get('linker_args', [])
+        extra_link_args = cfg.get('linker_args', []),
+        libraries = cfg.get('libraries', [])
     )
 
     args = ['build_ext', '--inplace']


### PR DESCRIPTION
I have the following use cases:

  * I want to wrap an existing library (libvpx and libwebm) for Python and I need add the libraries to link to
  * I have some autocompiled protobuf sources that I need to add to the compilation