### PR TITLE
Account for dist/arch/platform naming when searching for module path

### DIFF
--- a/cppimport/find.py
+++ b/cppimport/find.py
@@ -40,3 +40,31 @@ def find_module_cpppath(modulename):
             return outfilename
 
     return None
+
+
+def find_module_path(module_name: str, search_path: str = None) -> str:
+    """
+    Find the module path (pyd / so), while accounting for platform/arch naming
+    :param module_name: The name of the module
+    :param search_path: The path to search in. If None, searches system path.
+    :return: The full path to the library or None if not found.
+    """
+
+    # Use importlib if python 3.4+, else imp
+    if sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_info[1] >= 4):
+
+        from importlib.machinery import FileFinder, ExtensionFileLoader, EXTENSION_SUFFIXES
+        file_finder = FileFinder(search_path, (ExtensionFileLoader, EXTENSION_SUFFIXES))
+
+        # The search caches must be cleared to guaranteed find dynamically created modules
+        file_finder.invalidate_caches()
+        result = file_finder.find_spec(module_name)
+        return None if not result else result.origin
+    else:
+        from imp import find_module  # Deprecated in 3.4
+        try:
+            result = find_module(module_name, [search_path])
+        except ImportError:
+            result = None
+
+        return None if not result else result[1]

--- a/cppimport/find.py
+++ b/cppimport/find.py
@@ -42,7 +42,7 @@ def find_module_cpppath(modulename):
     return None
 
 
-def find_module_path(module_name: str, search_path: str = None) -> str:
+def find_module_path(module_name, search_path=None):
     """
     Find the module path (pyd / so), while accounting for platform/arch naming
     :param module_name: The name of the module

--- a/cppimport/importer.py
+++ b/cppimport/importer.py
@@ -30,7 +30,9 @@ def setup_module_data(fullname, filepath):
     return module_data
 
 def should_rebuild(module_data):
-    return (not os.path.exists(module_data['ext_path']) or
+    module_path = cppimport.find.find_module_path(module_data['fullname'], module_data['filedirname'])
+    return (not module_path or
+            not os.path.exists(module_path) or
             cppimport.config.should_force_rebuild or
             not cppimport.checksum.is_checksum_current(module_data))
 


### PR DESCRIPTION
I added a function find_module_path, which uses the built in importlib/imp modules to find the so/pyd file.

The reason for this change is that the pyd file seems to be generated with the wheel naming convention on windows (i.e module.cp35-win_amd64.pyd). This caused cppimport to always rebuild due to not finding it. Should_rebuild has been updated to use this new function.