### PR TITLE
Use importlib, remove getattr trick

### DIFF
--- a/cppimport/__init__.py
+++ b/cppimport/__init__.py
@@ -2,4 +2,4 @@ from cppimport.config import set_quiet, force_rebuild, file_exts, turn_off_stric
 from cppimport.importer import imp, imp_from_filepath
 from cppimport.templating import setup_pybind11
 
-from cppimport.importer import cppimport_impl as cppimport
+from cppimport.importer import imp as cppimport

--- a/cppimport/importer.py
+++ b/cppimport/importer.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import sysconfig
+import importlib
 
 import cppimport.config
 import cppimport.checksum
@@ -51,16 +52,16 @@ def imp_from_filepath(filepath, fullname = None):
     module_data = setup_module_data(fullname, filepath)
     if should_rebuild(module_data):
         template_and_build(filepath, module_data)
-        return __import__(fullname)
+        return importlib.import_module(fullname)
     else:
         quiet_print("Matching checksum for " + filepath + " --> not compiling")
         try:
-            return __import__(fullname)
+            return importlib.import_module(fullname)
         except ImportError as e:
             quiet_print(
                 "ImportError during import with matching checksum. Trying to rebuild.")
             template_and_build(filepath, module_data)
-            return __import__(fullname)
+            return importlib.import_module(fullname)
 
 def imp(fullname):
     # Search through sys.path to find a file that matches the module
@@ -71,10 +72,3 @@ def imp(fullname):
         )
     return imp_from_filepath(filepath, fullname)
 
-def cppimport_impl(fullname):
-    # Search through sys.path to find a file that matches the module
-    out_module = imp(fullname)
-    sub_module_names = fullname.split('.')[1:]
-    for sub_name in sub_module_names:
-        out_module = getattr(out_module, sub_name)
-    return out_module


### PR DESCRIPTION
This replaces usages of `__import__` with `importlib.import_module` as is suggested in [the importlib docs](). With that in place, we can remove the [`getattr` looping trick in `cppimport_impl`](https://github.com/tbenthompson/cppimport/blob/stable/cppimport/importer.py#L74) as is stated in the docs:

> The most important difference between these two functions is that `import_module()` returns the specified package or module (e.g. `pkg.mod`), while `__import__()` returns the top-level package or module (e.g. `pkg`).

This breaks usage of `cppimport.imp` and `cppimport.imp_from_filepath` that relies on `__import__` behaviour with nested modules. Most (if not all) usages of these functions that I found don't seem do this. Behaviour of `cppimport.cppimport` is the same.

I'll happily modify my PR if requested :slightly_smiling_face:.