### PR TITLE
for tensorflow usage add build only and return module filepath

### DIFF
--- a/cppimport/__init__.py
+++ b/cppimport/__init__.py
@@ -1,5 +1,5 @@
 from cppimport.config import set_quiet, force_rebuild, file_exts, turn_off_strict_prototypes
-from cppimport.importer import imp, imp_from_filepath
+from cppimport.importer import imp, imp_from_filepath, build
 from cppimport.templating import setup_pybind11
 
 from cppimport.importer import imp as cppimport


### PR DESCRIPTION
I just thought I would share a modification that allows cppimport to be used with tensorflow for building custom ops.  It is a 'build' method which returns a path to the compiled module, that can then be used by the tensorflow ```load_op_library``` method required for custom ops.  

It is necessary because attempting to import a library directly (not through tf) fails, so instead this builds the module and then simply returns the filepath to the module.

Example usage is:
```
import tensorflow as tf
import cppimport
my_op = tf.load_op_library(cppimport.build('src.my_op'))
```