### PR TITLE
Use with instruction to close files so unittesting doesn't cry

### DIFF
--- a/cppimport/checksum.py
+++ b/cppimport/checksum.py
@@ -17,7 +17,8 @@ def get_checksum_filepath(filepath):
 def calc_cur_checksum(file_lst, module_data):
     text = b""
     for filepath in file_lst:
-        text += open(filepath, 'rb').read()
+    	with open(filepath, 'rb') as f:
+        	text += f.read()
     return hashlib.md5(text).hexdigest()
 
 # Use a checksum to see if the file has been changed since the last compilation


### PR DESCRIPTION
There is a ResourceWarning: unclosed file, that is visible if running cppimport under python's unittest framework. Enclosing the read operation with 'with open(file, flags) as f' fixes the warning.