### PR TITLE
Clean up temporary files.

### DIFF
--- a/cppimport/importer.py
+++ b/cppimport/importer.py
@@ -67,6 +67,8 @@ def template_and_build(filepath, module_data):
     quiet_print("Compiling " + filepath)
     templating.run_templating(module_data)
     build_module.build_module(module_data)
+    if cppimport.config.quiet:
+        os.remove(module_data["rendered_src_filepath"])
     cppimport.checksum.checksum_save(module_data)
 
 def imp_from_filepath(filepath, fullname = None):


### PR DESCRIPTION
Remove rendered source after compilation (unless in non-quiet mode; this
could also be moved to a separate setting).

Move checksum to within compiled extension.  This is (effectively) legal
for .so files:
https://stackoverflow.com/questions/10106447/does-appending-arbitrary-data-to-an-elf-file-violate-the-elf-spec
and from testing works on Windows too.

Fixes some of https://github.com/tbenthompson/cppimport/issues/31.