### PR TITLE
Print more detailed info on ImportError

### DIFF
--- a/cppimport/importer.py
+++ b/cppimport/importer.py
@@ -64,9 +64,9 @@ def try_load(module_data):
     try:
         load_module(module_data)
         return True
-    except ImportError:
+    except ImportError as e:
         quiet_print(
-            "ImportError during import with matching checksum. Trying to rebuild."
+            f"ImportError during import with matching checksum: {e}. Trying to rebuild."
         )
         return False
 


### PR DESCRIPTION
Hello there, when using `cppimport` with complex libraries that have external C++ dependencies on macOS I sometimes encounter dyld load errors. In these cases, I found it very useful to print the actual `ImportError` that gives a hint which library could not be loaded.