### PR TITLE
Be compatible with python3.6

### DIFF
--- a/cppimport/__main__.py
+++ b/cppimport/__main__.py
@@ -16,7 +16,8 @@ def _run_from_commandline(raw_args):
         "--quiet", "-q", action="store_true", help="Only print critical log messages."
     )
 
-    subparsers = parser.add_subparsers(dest="action", required=True)
+    subparsers = parser.add_subparsers(dest="action")
+    subparsers.required = True
 
     build_parser = subparsers.add_parser(
         "build",


### PR DESCRIPTION
Fix this exception on python3.6:

  TypeError: __init__() got an unexpected keyword argument 'required'

---

(I saw 7e1e6b5a317d281b0bbf0c4ef0a696c8893e645a, but I hope you can merge this little compat code for us poor souls who need python3.6 at $dayjob.)