### PR TITLE
Import distutils after setuptools

### DIFF
--- a/cppimport/build_module.py
+++ b/cppimport/build_module.py
@@ -1,6 +1,4 @@
 import contextlib
-import distutils
-import distutils.sysconfig
 import io
 import logging
 import os
@@ -9,6 +7,8 @@ import tempfile
 
 import setuptools
 import setuptools.command.build_ext
+import distutils
+import distutils.sysconfig
 
 import cppimport
 from cppimport.filepaths import make_absolute

--- a/cppimport/build_module.py
+++ b/cppimport/build_module.py
@@ -7,6 +7,7 @@ import tempfile
 
 import setuptools
 import setuptools.command.build_ext
+
 import distutils
 import distutils.sysconfig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [tool.isort]
 profile = "black"
+# distutils is leaving stdlib. setuptools provides a compatibility import, but needs to be imported first
+known_thirdparty = ["distutils"]
+known_setuptools = ["setuptools"]
+sections = ["FUTURE", "STDLIB", "SETUPTOOLS", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 
 [tool.pytest.ini_options]
 addopts = "-s --tb=short"


### PR DESCRIPTION
distutils is being removed from Python in 3.12. To prepare for this, setuptools now bundles its own copy of distutils, which it patches into sys.modules, by default, since setuptools 60.

https://setuptools.pypa.io/en/latest/history.html#v60-0-0

To avoid importing two different distutils, import setuptools before distutils.

Bug-Debian: https://bugs.debian.org/1020571