### PR TITLE
Fix encoding issue by opening file in binary mode

### DIFF
--- a/cppimport/find.py
+++ b/cppimport/find.py
@@ -80,5 +80,5 @@ def _find_file_in_folders(filename, paths, opt_in):
 
 
 def _check_first_line_contains_cppimport(filepath):
-    with open(filepath, "r") as f:
-        return "cppimport" in f.readline()
+    with open(filepath, "rb") as f:
+        return b"cppimport" in f.readline()


### PR DESCRIPTION
Hello!
I encountered an `UnicodeDecodeError` when trying to import this file https://github.com/myd7349/Ongoing-Study/blob/wip-1014/python/cppimport/pocketfft/pocketfft.cpp in a Python script:

```python
#!/usr/bin/env python3
# coding: utf-8

import os.path
import urllib.request

_same_dir = lambda entry: os.path.join(os.path.dirname(__file__), entry)


def _download_pocketfft():
    sources = 'pocketfft.c', 'pocketfft.h'
    url = 'https://raw.githubusercontent.com/mreineck/pocketfft/master/'

    for source in sources:
        if not os.path.isfile(_same_dir(source)):
            urllib.request.urlretrieve(url + source, _same_dir(source))


_download_pocketfft()

import cppimport.import_hook
import pocketfft

print(dir(pocketfft))
```

My development environment:

- OS: Win10 x64(Simplfied Chinese, default encoding `GBK`)
- Anaconda 2022.05(Python 3.9.12)

![ci](https://user-images.githubusercontent.com/5435649/197163347-a59249be-1c63-46bc-885a-7abb0972ad63.png)

`pocketfft.cpp` is a UTF-8 source file(there are CJK characters in this file), and my Win10's default encoding is GBK. As a result, `open(filepath, 'r').readline()` might raise an `UnicodeDecodeError`.

This issue can be resolved by opening the file in binary mode.

With this patch, issue fixed:

![ci2](https://user-images.githubusercontent.com/5435649/197163586-87fb500e-c66a-4d10-a243-1a7b47885506.png)
