### PR TITLE
Remove dry_run keyword argument

### DIFF
--- a/cppimport/build_module.py
+++ b/cppimport/build_module.py
@@ -127,7 +127,7 @@ class BuildImportCppExt(setuptools.command.build_ext.build_ext):
             dest_filename = os.path.join(ext.libdest, os.path.basename(filename))
 
             distutils.file_util.copy_file(
-                src_filename, dest_filename, verbose=self.verbose, dry_run=self.dry_run
+                src_filename, dest_filename, verbose=self.verbose
             )
 
 


### PR DESCRIPTION
This patch fixes build error with latest release of setuptools.

> TypeError: copy_file() got an unexpected keyword argument 'dry_run'

Dry run functionality has been removed from setuptools v81.0.0+.

https://github.com/pypa/setuptools/pull/4872

https://github.com/pypa/distutils/pull/335