### PR TITLE
Upgrade CI tools and packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,11 @@ jobs:
       run:
         shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash -l {0}' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        mamba-version: "*"
         channels: conda-forge
+        conda-remove-defaults: true
         activate-environment: cppimport
         environment-file: environment.yml
         python-version: ${{ matrix.python-version }}
@@ -83,11 +83,11 @@ jobs:
     name: Build and publish Python distributions to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        mamba-version: "*"
         channels: conda-forge
+        conda-remove-defaults: true
         activate-environment: cppimport
         environment-file: environment.yml
     - name: Get history and tags for SCM versioning to work
@@ -96,10 +96,16 @@ jobs:
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Build sdist
       run: >- 
-        python setup.py sdist
+        pip install build && python -m build --sdist
+    - name: Publish distribution 📦 to TestPyPI
+      if: github.ref == 'refs/heads/main'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
-        verbose: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include README.md
-include VERSION
 recursive-include tests *.py
 recursive-include tests *.h
 recursive-include tests *.cpp

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ from setuptools import setup
 description = open("README.md").read()
 
 setup(
-    use_scm_version={"version_scheme": "post-release"},
-    setup_requires=["setuptools_scm"],
     packages=["cppimport"],
     install_requires=["mako", "pybind11", "filelock", "setuptools"],
     zip_safe=False,
@@ -23,7 +21,6 @@ setup(
         "Operating System :: OS Independent",
         "Operating System :: POSIX",
         "Topic :: Software Development",
-        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: C++",
     ],


### PR DESCRIPTION
Upgrade CI tools and packages to current versions to minimize number of warnings during release.